### PR TITLE
Feat(player): change operations in player mode

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -35,10 +35,14 @@ class Player extends React.Component {
         this.togglePlay = () => {
             this.props.togglePlay()
         }
-        this.handleClick = (e, isRight) => {
+        this.handleClick = (e) => {
             e.preventDefault();
             debug('event', e)
-            if(isRight) {
+            if(this.props.contentType === 'movie') {
+                this.togglePlay();
+                return;
+            }
+            if(e.button !== 0) {
                 debug('right click');
                 this.props.changePage(1);
             } else {
@@ -56,24 +60,12 @@ class Player extends React.Component {
 
     render() {
         return (
-            <div>
-                {this.props.contentType === 'movie' ? (
-                    <div
-                        onClick={this.togglePlay}
-                    >
-                        <canvas ref={this.setCanvasElement} />
-                        <p><BackButton /></p>
-                    </div>
-                ) : (
-                    <div
-                        onClick={(e) => this.handleClick(e)}
-                        onContextMenu={(e) => this.handleClick(e, true)}
-                    >
-                        <canvas ref={this.setCanvasElement} />
-                        <p><BackButton /></p>
-                    </div>
-                )
-                }
+            <div
+                onClick={(e) => this.handleClick(e)}
+                onContextMenu={(e) => this.handleClick(e, true)}
+            >
+                <canvas ref={this.setCanvasElement} />
+                <p><BackButton /></p>
             </div>
         );
     }

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -61,8 +61,8 @@ class Player extends React.Component {
     render() {
         return (
             <div
-                onClick={(e) => this.handleClick(e)}
-                onContextMenu={(e) => this.handleClick(e)}
+                onClick={this.handleClick}
+                onContextMenu={this.handleClick}
             >
                 <canvas ref={this.setCanvasElement} />
                 <p><BackButton /></p>

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -62,7 +62,7 @@ class Player extends React.Component {
         return (
             <div
                 onClick={(e) => this.handleClick(e)}
-                onContextMenu={(e) => this.handleClick(e, true)}
+                onContextMenu={(e) => this.handleClick(e)}
             >
                 <canvas ref={this.setCanvasElement} />
                 <p><BackButton /></p>

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -44,13 +44,35 @@ class Player extends React.Component {
     }
 
     render() {
+        const imageClick = (e, isRight) => {
+            e.preventDefault();
+            if(isRight) {
+                this.props.changePage(1);
+            } else {
+                this.props.changePage(-1);
+            }
+        }
+
+        const showingContents = this.props.contentType === 'movie' ? (
+            <div
+                onClick={this.togglePlay}
+            >
+                <canvas ref={this.setCanvasElement} />
+                <p><BackButton /></p>
+            </div>
+        ) : (
+            <div
+                onClick={(e) => imageClick(e)}
+                onContextMenu={(e) => imageClick(e, true)}
+            >
+                <canvas ref={this.setCanvasElement} />
+                <p><BackButton /></p>
+            </div>
+        );
+
         return (
             <div>
-                <canvas ref={this.setCanvasElement} />
-                <p onClick={this.changePage(-1)}>prev</p>
-                <p onClick={this.changePage(1)}>next</p>
-                <p onClick={this.togglePlay}>play/stop</p>
-                <p><BackButton /></p>
+                { showingContents }
             </div>
         );
     }

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -35,6 +35,17 @@ class Player extends React.Component {
         this.togglePlay = () => {
             this.props.togglePlay()
         }
+        this.handleClick = (e, isRight) => {
+            e.preventDefault();
+            debug('event', e)
+            if(isRight) {
+                debug('right click');
+                this.props.changePage(1);
+            } else {
+                debug('left click');
+                this.props.changePage(-1);
+            }
+        }
     }
 
     componentDidMount() {
@@ -44,35 +55,25 @@ class Player extends React.Component {
     }
 
     render() {
-        const imageClick = (e, isRight) => {
-            e.preventDefault();
-            if(isRight) {
-                this.props.changePage(1);
-            } else {
-                this.props.changePage(-1);
-            }
-        }
-
-        const showingContents = this.props.contentType === 'movie' ? (
-            <div
-                onClick={this.togglePlay}
-            >
-                <canvas ref={this.setCanvasElement} />
-                <p><BackButton /></p>
-            </div>
-        ) : (
-            <div
-                onClick={(e) => imageClick(e)}
-                onContextMenu={(e) => imageClick(e, true)}
-            >
-                <canvas ref={this.setCanvasElement} />
-                <p><BackButton /></p>
-            </div>
-        );
-
         return (
             <div>
-                { showingContents }
+                {this.props.contentType === 'movie' ? (
+                    <div
+                        onClick={this.togglePlay}
+                    >
+                        <canvas ref={this.setCanvasElement} />
+                        <p><BackButton /></p>
+                    </div>
+                ) : (
+                    <div
+                        onClick={(e) => this.handleClick(e)}
+                        onContextMenu={(e) => this.handleClick(e, true)}
+                    >
+                        <canvas ref={this.setCanvasElement} />
+                        <p><BackButton /></p>
+                    </div>
+                )
+                }
             </div>
         );
     }


### PR DESCRIPTION
player modeでの操作を変更．今まで画面下部にあったpタグのクリックで画像の切り替え，動画の再生/停止を行っていたが，それを廃止してマウスクリックの左右などで操作するようにした．
- 画像: playなら右クリックで次のページ/左クリックで前のページ．
- 動画: playなら左クリックで再生/停止

という様に実装した
この操作変更は，2017年7月27日のfabnavi mtgにて決定