### PR TITLE
動画の表示を改善

### DIFF
--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -5,7 +5,7 @@ import Debug from 'debug';
 
 import BackButton from './BackButton';
 import MainView from '../player/MainView';
-import { playerChangePage, togglePlaying } from '../actions/player'
+import { playerChangePage } from '../actions/player'
 
 const debug = Debug('fabnavi:jsx:Player');
 
@@ -32,14 +32,20 @@ class Player extends React.Component {
         this.changePage = (step) => () => {
             this.props.changePage(step)
         }
-        this.togglePlay = () => {
-            this.props.togglePlay()
+        this.state = {
+            isPlaying: false
         }
         this.handleClick = (e) => {
             e.preventDefault();
             debug('event', e)
             if(this.props.contentType === 'movie') {
-                this.togglePlay();
+                const video = document.querySelector('video');
+                if(this.state.isPlaying) {
+                    video.pause();
+                } else {
+                    video.play();
+                }
+                this.setState({ isPlaying: !this.state.isPlaying });
                 return;
             }
             if(e.button !== 0) {
@@ -178,8 +184,7 @@ const mapStateToProps = (state) => (
         project: state.player.project,
         page: state.player.page,
         config: state.player.config,
-        contentType: state.player.contentType,
-        isPlaying: state.player.isPlaying
+        contentType: state.player.contentType
     }
 );
 
@@ -187,9 +192,6 @@ const mapDispatchToProps = (dispatch) => (
     {
         changePage: (step) => {
             dispatch(playerChangePage({ step: step }));
-        },
-        togglePlay: () => {
-            dispatch(togglePlaying({}));
         }
     }
 );
@@ -197,11 +199,9 @@ const mapDispatchToProps = (dispatch) => (
 Player.propTypes = {
     project: PropTypes.object,
     contentType: PropTypes.string,
-    isPlaying: PropTypes.bool,
     mode: PropTypes.string,
     page: PropTypes.number,
     config: PropTypes.object,
-    changePage: PropTypes.func,
-    togglePlay: PropTypes.func
+    changePage: PropTypes.func
 };
 export default connect(mapStateToProps, mapDispatchToProps)(Player);

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -24,8 +24,6 @@ class Player extends React.Component {
         this.currentState = '';
 
         this.updateCanvas = this.updateCanvas.bind(this);
-        this.video = document.createElement('video');
-        this.renderingTimer = null;
         this.setCanvasElement = cvs => {
             this.canvasElement = cvs
         }
@@ -70,7 +68,15 @@ class Player extends React.Component {
                 onClick={this.handleClick}
                 onContextMenu={this.handleClick}
             >
-                <canvas ref={this.setCanvasElement} />
+                <style jsx>{`
+                    video::-webkit-media-controls-panel {
+                        display: flex !important;
+                        opacity: 1 !important;
+                    }
+                `}</style>
+                {this.props.contentType === 'movie' ?
+                    <video id='video' controls={true} src={this.props.project.content[0].figure.file.file.url} preload='auto'/> :
+                    <canvas ref={this.setCanvasElement} />}
                 <p><BackButton /></p>
             </div>
         );
@@ -88,24 +94,6 @@ class Player extends React.Component {
 
         if(!isValidProject()) {
             debug('invalid project data', project);
-            return;
-        }
-
-        if( this.props.contentType === 'movie') {
-            if(this.video.src === '') {
-                this.video.width = window.screen.width;
-                this.video.height = window.screen.height;
-                this.video.src = project.content[0].figure.file.file.url;
-            }
-            if(this.props.isPlaying) {
-                this.renderingTimer = setInterval(() => {
-                    this.canvas.render(this.video, this.props.config);
-                }, 30);
-                this.video.play();
-            } else {
-                clearInterval(this.renderingTimer);
-                this.video.pause();
-            }
             return;
         }
 

--- a/src/reducers/player.js
+++ b/src/reducers/player.js
@@ -13,7 +13,6 @@ const initialState = {
     page: 0,
     project: null,
     currentTime: 0,
-    isPlaying: false,
     config: {
         x: 0,
         y: 0,
@@ -65,14 +64,6 @@ export default handleActions({
         return Object.assign({}, state, {
             mode: nextMode(state)
         });
-    },
-    TOGGLE_PLAYING: (state, action) => {
-        if(state.contentType === 'movie') {
-            return Object.assign({}, state, {
-                isPlaying: !state.isPlaying
-            });
-        }
-        return state;
     }
 }, initialState);
 


### PR DESCRIPTION
#72 
- 動画projectの時、canvasの代わりにvideoタグを直接renderした
- `props.isPlaying`を消してPlayer Componentのstateで管理するようにした