### PR TITLE
fix: after edit project

### DIFF
--- a/src/middleware/epics/index.js
+++ b/src/middleware/epics/index.js
@@ -64,11 +64,15 @@ const fetchProjectsEpic = (action$, store) =>
         .map(response => receiveProjects(response))
 ;
 
-const updateProjectEpic = action$ =>
+const updateProjectEpic = (action$, store) =>
     action$.ofType(UPDATE_PROJECT)
         .do(action =>
             api.updateProject(action.payload)
-                .then(res => debug('update success', res))
+                .then(res => {
+                    debug('update success', res.data.id);
+                    store.dispatch(fetchProjects(0, 'all'));
+                    store.dispatch(push(`/detail/${res.data.id}`));
+                })
                 .catch(err => debug(err)))
         .ignoreElements()
 ;

--- a/src/middleware/epics/index.js
+++ b/src/middleware/epics/index.js
@@ -33,7 +33,7 @@ const fetchOwnProjectsEpic = (action$) =>
     action$.ofType('@@router/LOCATION_CHANGE')
         .filter(action => action.payload.pathname === '/myprojects')
         .map(action => fetchProjects(action.payload, 'myOwn'));
-;
+
 const fetchProjectEpic = (action$) =>
     action$.ofType('@@router/LOCATION_CHANGE')
         .filter(action => action.payload.pathname !== '/' &&
@@ -44,8 +44,7 @@ const fetchProjectEpic = (action$) =>
             const projectId = action.payload.pathname.match(/\d+/)[0];
             return api.getProject(projectId)
         })
-        .map(({ data }) => receiveProject(data))
-;
+        .map(({ data }) => receiveProject(data));
 
 const fetchProjectsEpic = (action$, store) =>
     action$.ofType(FETCH_PROJECTS)
@@ -53,7 +52,7 @@ const fetchProjectsEpic = (action$, store) =>
         .switchMap(action => {
             const{ mode, page } = action.payload;
             let fetch = api.fetchAllProjects.bind(api);
-            if( mode === 'myOwn'){
+            if( mode === 'myOwn') {
                 fetch = api.fetchOwnProjects.bind(api);
             }
             return Rx.Observable.fromPromise(fetch(page))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,10 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -4572,7 +4576,7 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7, rc@^1.2.1:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^15.6.1:
+react-dom@^15.4.2, react-dom@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
   dependencies:
@@ -4591,6 +4595,14 @@ react-hot-loader@^1.3.1:
   dependencies:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
+
+react-materialize@^1.0.6:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/react-materialize/-/react-materialize-1.0.13.tgz#94acef3800fb62410931525cc8dc5a6f9f7ad4bf"
+  dependencies:
+    classnames "^2.2.5"
+    react "^15.4.2"
+    react-dom "^15.4.2"
 
 react-redux@^5.0.5:
   version "5.0.5"
@@ -4633,7 +4645,7 @@ react-router@^4.1.1:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react@^15.6.1:
+react@^15.4.2, react@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
   dependencies:


### PR DESCRIPTION
#77 

- プロジェクトを編集、保存した後Detailに飛ばすようにした
- detailからtopに移動した際、プロジェクトの編集を反映させるために`store.dispatch(push(`/detail/${res.data.id}`));`してしまっている