### PR TITLE
project-cardの枠線にradiusを適用されてない問題を解決した

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -52,6 +52,7 @@ export default class ProjectCard extends React.Component {
                 }
                 .selected-project{
                     box-shadow: 0 0 0 3px #FF0000;
+                    border-radius: 7px 7px 7px 7px;
                 }
                 .project-name {
                     font-size:17pt;

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -156,6 +156,7 @@ const MenuItem = ({ actionName, onClick }) =>
             }
             div {
                 background-color: rgba(125, 125, 125, 0.5);
+                border-radius: 7px 7px 0 0;
             }
             div:hover {
                 background-color: rgba(60, 60, 60, 0.5);


### PR DESCRIPTION
project-cardを選択した時に赤い枠線が出現するが、マウスポインタがその選択されているproject-cardを離れると出現している赤い枠線のradiusが適用されていなかったのでそれを解決した。
![赤い枠線](https://gyazo.com/7ef1134e69654576c33afe1660844c50.png)