### PR TITLE
Re-design-project-card

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -59,6 +59,7 @@ export default class ProjectCard extends React.Component {
                     height:40px;
                     font-size:17pt;
                     margin: 5px auto;
+                    padding-top: 7px;
                     text-align: center;
                     overflow: hidden;
                     white-space: nowrap;


### PR DESCRIPTION
project-cardないのproject-nameの高さが若干上部によっていたので、中央一になるように修正した。
![project-name](https://gyazo.com/94f9e9b66aaabaee9f0b7be6c6ecbc26.png)