### PR TITLE
project-card-shadow-radius

### DIFF
--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -26,7 +26,7 @@ export default class ProjectCard extends React.Component {
                     position: relative;
                     width:250px;
                     height:300px;
-                    border-radius: 0px 0px 7px 7px;
+                    border-radius: 7px 7px 7px 7px;
                     box-shadow: 6px 6px 2px #DDD;
                     transition: 0.1s ease-in-out;
                 }


### PR DESCRIPTION
project-cardのボックスシャドウに角丸が適用されていなかったので、角丸に修正した。
![角丸](https://gyazo.com/4fb159e72c4193f208bf376b5d347777.png)