### PR TITLE
Fix(workspace): fix strokeRect position and color

### DIFF
--- a/src/components/WorkSpace.jsx
+++ b/src/components/WorkSpace.jsx
@@ -43,8 +43,8 @@ export default class WorkSpace extends Component {
         debug('current config', this.state);
         ctx.fillStyle = this.state.space.color;
         ctx.fillRect(x, y, width, height);
-        ctx.fillStyle = this.state.border.color;
-        ctx.strokeRect(x, y, width, height);
+        ctx.strokeStyle = this.state.border.color;
+        ctx.strokeRect(x + 100, y + 100, width - 100, height - 100);
     }
 
     handleColorChange(obj) {


### PR DESCRIPTION
strokeReactが描画される位置と色を変えられるようにした．
多分，全体に線を引くなら `beginPath()` とか使ったほうがいいかもしれません．