### PR TITLE
close #198  次の動画に移った直後に、前の動画のサムネイルをクリックしても戻れないことがあ

### DIFF
--- a/src/renderer/components/Player.js
+++ b/src/renderer/components/Player.js
@@ -5,8 +5,8 @@ import Debug from 'debug';
 
 import MainView from '../player/MainView';
 import { playerChangePage } from '../actions/player'
-import VideoPlayer from './VideoPlayer';
-import ImageSelector from './ImageSelector';
+import VideoPlayer from './Player/VideoPlayer';
+import ImageSelector from './Player/ImageSelector';
 
 import { buildFigureUrl } from '../utils/playerUtils'
 
@@ -57,6 +57,10 @@ class Player extends React.Component {
                 console.log('Not Implemented yet');
             }
         }
+
+        this.videoChanged = (index) => {
+            this.setState({ index: index });
+        }
     }
 
     componentDidMount() {
@@ -82,7 +86,7 @@ class Player extends React.Component {
                     }
                 `}</style>
                 {this.props.contentType === 'movie' ?
-                    <VideoPlayer project={this.state.project} toggleUpdate={this.state.toggleUpdate} index={this.state.index} handleClick={this.handleClick} size={this.props.size}/> :
+                    <VideoPlayer project={this.state.project} toggleUpdate={this.state.toggleUpdate} index={this.state.index} handleClick={this.handleClick} videoChanged={this.videoChanged} size={this.props.size}/> :
                     <canvas ref={this.setCanvasElement} onClick={this.handleClick}/>}
 
                 {this.props.project ?

--- a/src/renderer/components/Player/ImageSelector.js
+++ b/src/renderer/components/Player/ImageSelector.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Debug from 'debug';
-import { buildFigureUrl } from '../utils/playerUtils'
-import { assetsPath } from '../utils/assetsUtils';
+import { buildFigureUrl } from '../../utils/playerUtils'
+import { assetsPath } from '../../utils/assetsUtils';
 
 const debug = Debug('fabnavi:jsx:ImageSelector');
 
@@ -88,6 +88,7 @@ const Thumbnail = ({ figure, index, onClick }) => (
                 width: 200px;
                 height: auto;
                 margin: 0;
+                cursor: pointer;
             }
             p {
                 margin: 0;

--- a/src/renderer/components/Player/VideoPlayer.js
+++ b/src/renderer/components/Player/VideoPlayer.js
@@ -5,7 +5,7 @@ import Debug from 'debug';
 import videojs from 'video.js'
 import 'videojs-playlist';
 
-import { buildCaptions, buildFigureUrl } from '../utils/playerUtils'
+import { buildCaptions, buildFigureUrl } from '../../utils/playerUtils'
 
 const debug = Debug('fabnavi:jsx:VideoPlayer');
 
@@ -59,6 +59,10 @@ class VideoPlayer extends React.Component {
         this.player = videojs(this.videoNode);
         this.updatePlaylist(this.props.project);
         this.player.playlist.autoadvance(0)
+        this.player.on('play', () => {
+            this.props.videoChanged(this.player.playlist.currentIndex());
+            this.setState({ index: this.player.playlist.currentIndex() });
+        })
     }
 
     // destroy player on unmount
@@ -115,7 +119,8 @@ VideoPlayer.propTypes = {
     index: PropTypes.number,
     figures: PropTypes.array,
     toggleUpdate: PropTypes.bool,
-    size: PropTypes.string
+    size: PropTypes.string,
+    videoChanged: PropTypes.func
 };
 
 export default connect(mapStateToProps)(VideoPlayer);


### PR DESCRIPTION
- 問題を整理するためにファイルを移動

  - ImageSelector.js
  - VideoPlayer.js

- 動画連続再生時に、ビデオが新しいものに切り替わってもVideoPlayerないのindexが更新されないことが原因だったため、それを解消