### PR TITLE
Fix #378, #379: 要約再生時，短いキャプションが飛ばされてしまう

### DIFF
--- a/src/renderer/utils/videojs-summary-play/videojs-summary-play.js
+++ b/src/renderer/utils/videojs-summary-play/videojs-summary-play.js
@@ -14,13 +14,23 @@ class SummaryPlayButton extends vjsButton {
     constructor(player, options) {
         super(player, options);
         this.isSummaryPlaying = false;
+        this.cue = [];
+
+        player.on('loadeddata', () => {
+            this.cues = [];
+            if (player.textTracks().tracks_[0].cues_.length > 0) {
+                this.cues = player.textTracks().tracks_[0].cues_;
+                this.cues.sort((a, b) => a.startTime - b.startTime);
+            }
+        })
+
         player.on('timeupdate', () => {
-            if(this.isSummaryPlaying) {
-                if(player.textTracks().tracks_[0] && player.textTracks().tracks_[0].activeCues_.length > 0) {
-                    player.playbackRate(1.0);
-                } else {
-                    player.playbackRate(8.0);
-                }
+            if (this.isSummaryPlaying) {
+                var hasActiveCues = this.cues.some((cue) => {
+                    if (player.currentTime() > cue.startTime - 2 && player.currentTime() < cue.endTime) return true;
+                })
+                if (hasActiveCues) player.playbackRate(1.0);
+                else player.playbackRate(8.0);
             }
         });
     }


### PR DESCRIPTION
before: 字幕が表示されたら，再生速度を変更
after: 字幕が表示される１～２秒前に，再生速度を変更